### PR TITLE
Add universal Emitter implementation.

### DIFF
--- a/dist/abortcontroller.js
+++ b/dist/abortcontroller.js
@@ -15,19 +15,58 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
     return;
   }
 
-  var Emitter = function Emitter() {
-    var _this = this;
+  var Emitter = function () {
+    function Emitter() {
+      _classCallCheck(this, Emitter);
 
-    _classCallCheck(this, Emitter);
+      this.listeners = {};
+    }
 
-    var delegate = document.createDocumentFragment();
-    var methods = ['addEventListener', 'dispatchEvent', 'removeEventListener'];
-    methods.forEach(function (method) {
-      return _this[method] = function () {
-        return delegate[method].apply(delegate, arguments);
-      };
-    });
-  };
+    _createClass(Emitter, [{
+      key: 'addEventListener',
+      value: function addEventListener(type, callback) {
+        if (!(type in this.listeners)) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(callback);
+      }
+    }, {
+      key: 'removeEventListener',
+      value: function removeEventListener(type, callback) {
+        if (!(type in this.listeners)) {
+          return;
+        }
+        var stack = this.listeners[type];
+        for (var i = 0, l = stack.length; i < l; i++) {
+          if (stack[i] === callback) {
+            stack.splice(i, 1);
+            return;
+          }
+        }
+      }
+    }, {
+      key: 'dispatchEvent',
+      value: function dispatchEvent(event) {
+        var _this = this;
+
+        if (!(event.type in this.listeners)) {
+          return;
+        }
+        var debounce = function debounce(callback) {
+          setTimeout(function () {
+            return callback.call(_this, event);
+          });
+        };
+        var stack = this.listeners[event.type];
+        for (var i = 0, l = stack.length; i < l; i++) {
+          debounce(stack[i]);
+        }
+        return !event.defaultPrevented;
+      }
+    }]);
+
+    return Emitter;
+  }();
 
   var AbortSignal = function (_Emitter) {
     _inherits(AbortSignal, _Emitter);

--- a/dist/browser-polyfill.js
+++ b/dist/browser-polyfill.js
@@ -15,19 +15,58 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
     return;
   }
 
-  var Emitter = function Emitter() {
-    var _this = this;
+  var Emitter = function () {
+    function Emitter() {
+      _classCallCheck(this, Emitter);
 
-    _classCallCheck(this, Emitter);
+      this.listeners = {};
+    }
 
-    var delegate = document.createDocumentFragment();
-    var methods = ['addEventListener', 'dispatchEvent', 'removeEventListener'];
-    methods.forEach(function (method) {
-      return _this[method] = function () {
-        return delegate[method].apply(delegate, arguments);
-      };
-    });
-  };
+    _createClass(Emitter, [{
+      key: 'addEventListener',
+      value: function addEventListener(type, callback) {
+        if (!(type in this.listeners)) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(callback);
+      }
+    }, {
+      key: 'removeEventListener',
+      value: function removeEventListener(type, callback) {
+        if (!(type in this.listeners)) {
+          return;
+        }
+        var stack = this.listeners[type];
+        for (var i = 0, l = stack.length; i < l; i++) {
+          if (stack[i] === callback) {
+            stack.splice(i, 1);
+            return;
+          }
+        }
+      }
+    }, {
+      key: 'dispatchEvent',
+      value: function dispatchEvent(event) {
+        var _this = this;
+
+        if (!(event.type in this.listeners)) {
+          return;
+        }
+        var debounce = function debounce(callback) {
+          setTimeout(function () {
+            return callback.call(_this, event);
+          });
+        };
+        var stack = this.listeners[event.type];
+        for (var i = 0, l = stack.length; i < l; i++) {
+          debounce(stack[i]);
+        }
+        return !event.defaultPrevented;
+      }
+    }]);
+
+    return Emitter;
+  }();
 
   var AbortSignal = function (_Emitter) {
     _inherits(AbortSignal, _Emitter);

--- a/src/abortcontroller.js
+++ b/src/abortcontroller.js
@@ -6,12 +6,39 @@
   }
 
   class Emitter {
-    constructor() {
-      const delegate = document.createDocumentFragment();
-      const methods = ['addEventListener', 'dispatchEvent', 'removeEventListener'];
-      methods.forEach(method =>
-        this[method] = (...args) => delegate[method](...args)
-      );
+    constructor () {
+      this.listeners = {}
+    }
+    addEventListener (type, callback) {
+      if (!(type in this.listeners)) {
+        this.listeners[type] = [];
+      }
+      this.listeners[type].push(callback);
+    }
+    removeEventListener (type, callback) {
+      if (!(type in this.listeners)) {
+        return;
+      }
+      const stack = this.listeners[type];
+      for (let i = 0, l = stack.length; i < l; i++) {
+        if (stack[i] === callback){
+          stack.splice(i, 1);
+          return;
+        }
+      }
+    }
+    dispatchEvent (event) {
+      if (!(event.type in this.listeners)) {
+        return;
+      }
+      const debounce = callback => {
+        setTimeout(() => callback.call(this, event));
+      };
+      const stack = this.listeners[event.type];
+      for (let i = 0, l = stack.length; i < l; i++) {
+        debounce(stack[i]);
+      }
+      return !event.defaultPrevented;
     }
   }
 


### PR DESCRIPTION
Changes Emitter implementation to be universal. `document`, `window`, `Element` and other classes that implement the `EventTarget` interface are not available in web workers or Node.js. `XMLHttpRequest` is available in workers, but not Node.js.

Implementation is based on [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget#Example) with deferred callback executions.

Fixes #11.