### PR TITLE
Add fallback for Event creation outside of DOM.

### DIFF
--- a/dist/abortcontroller.js
+++ b/dist/abortcontroller.js
@@ -114,14 +114,24 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
     _createClass(AbortController, [{
       key: 'abort',
       value: function abort() {
+        var event = void 0;
         try {
-          this.signal.dispatchEvent(new Event('abort'));
+          event = new Event('abort');
         } catch (e) {
-          // For Internet Explorer 11:
-          var event = document.createEvent('Event');
-          event.initEvent('abort', false, true);
-          this.signal.dispatchEvent(event);
+          if (typeof document !== 'undefined') {
+            // For Internet Explorer 11:
+            event = document.createEvent('Event');
+            event.initEvent('abort');
+          } else {
+            // Fallback where document isn't available:
+            event = {
+              type: 'abort',
+              bubbles: false,
+              cancelable: false
+            };
+          }
         }
+        this.signal.dispatchEvent(event);
       }
     }, {
       key: 'toString',

--- a/dist/browser-polyfill.js
+++ b/dist/browser-polyfill.js
@@ -114,14 +114,24 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
     _createClass(AbortController, [{
       key: 'abort',
       value: function abort() {
+        var event = void 0;
         try {
-          this.signal.dispatchEvent(new Event('abort'));
+          event = new Event('abort');
         } catch (e) {
-          // For Internet Explorer 11:
-          var event = document.createEvent('Event');
-          event.initEvent('abort', false, true);
-          this.signal.dispatchEvent(event);
+          if (typeof document !== 'undefined') {
+            // For Internet Explorer 11:
+            event = document.createEvent('Event');
+            event.initEvent('abort');
+          } else {
+            // Fallback where document isn't available:
+            event = {
+              type: 'abort',
+              bubbles: false,
+              cancelable: false
+            };
+          }
         }
+        this.signal.dispatchEvent(event);
       }
     }, {
       key: 'toString',

--- a/src/abortcontroller.js
+++ b/src/abortcontroller.js
@@ -68,14 +68,24 @@
       this.signal = new AbortSignal();
     }
     abort() {
+      let event;
       try {
-        this.signal.dispatchEvent(new Event('abort'));
+        event = new Event('abort');
       } catch (e) {
-        // For Internet Explorer 11:
-        const event = document.createEvent('Event');
-        event.initEvent('abort', false, true);
-        this.signal.dispatchEvent(event);
+        if (typeof document !== 'undefined') {
+          // For Internet Explorer 11:
+          event = document.createEvent('Event');
+          event.initEvent('abort');
+        } else {
+          // Fallback where document isn't available:
+          event = { 
+            type: 'abort', 
+            bubbles: false, 
+            cancelable: false 
+          };
+        }
       }
+      this.signal.dispatchEvent(event);
     }
     toString() {
       return '[object AbortController]';


### PR DESCRIPTION
Add fallback when neither `Event` or `document` are available to create an event (e.g. https://travis-ci.org/github/fetch/builds/337224091).

Initialize all events with default config (`bubbles: false`, `cancelable: false`).