### PR TITLE
Initialize AbortSignal.onabort as null.

### DIFF
--- a/dist/abortcontroller.js
+++ b/dist/abortcontroller.js
@@ -79,6 +79,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
       var _this2 = _possibleConstructorReturn(this, (AbortSignal.__proto__ || Object.getPrototypeOf(AbortSignal)).call(this));
 
       _this2.aborted = false;
+      _this2.onabort = null;
       return _this2;
     }
 

--- a/dist/browser-polyfill.js
+++ b/dist/browser-polyfill.js
@@ -79,6 +79,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
       var _this2 = _possibleConstructorReturn(this, (AbortSignal.__proto__ || Object.getPrototypeOf(AbortSignal)).call(this));
 
       _this2.aborted = false;
+      _this2.onabort = null;
       return _this2;
     }
 

--- a/src/abortcontroller.js
+++ b/src/abortcontroller.js
@@ -47,6 +47,7 @@
       super();
 
       this.aborted = false;
+      this.onabort = null;
     }
     toString() {
       return '[object AbortSignal]';

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -6,6 +6,21 @@ const TESTPAGE_URL = 'file://' + path.resolve(__dirname, 'testpage.html').replac
 
 describe('basic tests', () => {
 
+  it('AbortSignal constructor', () => {
+    browser.url(TESTPAGE_URL);
+    const res = browser.executeAsync(async (done) => {
+      const signal = new AbortSignal();
+      if (signal.aborted !== false) {
+        done('FAIL');
+      }
+      if (signal.onabort !== null) {
+        done('FAIL');
+      }
+      done('PASS');
+    });
+    expect(res.value).toBe('PASS');
+  });
+
   it('Request is patched', () => {
     browser.url(TESTPAGE_URL);
     const res = browser.executeAsync(async (done) => {


### PR DESCRIPTION
Tiny thing. Just for parity.

```js
console.log(new AbortController().signal); // AbortSignal { aborted: false, onabort: null }
```