### PR TITLE
Exclude Safari when validating if AbortController exists

### DIFF
--- a/src/abortcontroller-polyfill.js
+++ b/src/abortcontroller-polyfill.js
@@ -3,7 +3,10 @@ import AbortController, {AbortSignal} from './abortcontroller';
 (function(self) {
   'use strict';
 
-  if (self.AbortController) {
+  if (
+    self.AbortController &&
+    (!self.navigator || !self.navigator.userAgent.match(/version\/[\d|.]+ safari\/[\d|.]+$/i))
+  ) {
     return;
   }
 

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -4,7 +4,10 @@ import abortableFetch from './abortableFetch';
 (function(self) {
   'use strict';
 
-  if (self.AbortController) {
+  if (
+    self.AbortController &&
+    (!self.navigator || !self.navigator.userAgent.match(/version\/[\d|.]+ safari\/[\d|.]+$/i))
+  ) {
     return;
   }
 


### PR DESCRIPTION
### What does this PR do?

As reported on #23, Safari claims to support `AbortController`, but while the object is indeed present, calling `.abort()` doesn't do anything.

@mo tested it on the technical preview and the issue is still there, so the easiest solution we came up with is, on Safari, apply the polyfill even if `AbortController` exists.

### How should it be tested?

I created [this sandbox](https://codesandbox.io/s/zwq18q68x4) with a simple script that creates a request and aborts it right away.

You can test how it works on other browsers but doesn't on Safari.

In order to test the fix, **you can**:

1. Build this branch `npm run build`.
2. Download the sandbox (last icon on the top left)
3. Copy the `dist` to the sandbox's `node_modules/abortcontroller-polyfill` (or use `npm/yarn link`).
4. Run `npm start` on the sandbox.

> You can start something from scratch too, but I think this is easiest.

### Notes

- I changed the `RegExp` a little bit because Chrome's user agent also ends with `Safari/...`.
- Before doing any change, I tried running the tests to make sure my changes wouldn't break anything but I got `Failed: unknown error: call function result missing 'value'`, and since there wasn't a Selenium script for Safari (and I not any good with Selenium), I didn't test the change.

