### PR TITLE
Define the properties as being non-enumerable as per the specification

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -9,9 +9,20 @@ import {nativeAbortControllerIsBroken} from './utils';
     return;
   }
 
-  self.AbortController = AbortController;
-  self.AbortSignal = AbortSignal;
-
+  Object.defineProperty(self, "AbortController", {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: AbortController
+  });
+  
+   Object.defineProperty(self, "AbortSignal", {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: AbortSignal
+  });
+  
   if (!self.fetch) {
     console.warn('fetch() is not available, cannot install abortcontroller-polyfill');
     return;


### PR DESCRIPTION
The specification for AbortController and AbortSignal defines the objects as interfaces:
https://dom.spec.whatwg.org/#interface-abortcontroller
```WebIDL
[Constructor,
 Exposed=(Window,Worker)]
interface AbortController {
  [SameObject] readonly attribute AbortSignal signal;

  void abort();
};
```

https://dom.spec.whatwg.org/#interface-AbortSignal
```WebIDL
[Exposed=(Window,Worker)]
interface AbortSignal : EventTarget {
  readonly attribute boolean aborted;

  attribute EventHandler onabort;
};
```

Interfaces in IDL are defined as being writable, configurable and non-enumerable --> https://heycam.github.io/webidl/#es-interfaces

Using the assignment operator `=` makes the value become writable, configurable and enumerable. Switching from using the assignment operator to using `Object.defineProperty` allows us to customise the properties attributes.