### PR TITLE
feat: added polyfill for AbortSignal.timeout - fixes #73

### DIFF
--- a/src/abortcontroller.js
+++ b/src/abortcontroller.js
@@ -75,6 +75,11 @@ export class AbortSignal extends Emitter {
 
     super.dispatchEvent(event);
   }
+  static timeout(duration) {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), duration);
+    return controller.signal;
+  }
 }
 
 export class AbortController {

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -347,6 +347,25 @@ const runBasicTests = (testSuiteTitle, TESTPAGE_URL) => {
       });
       expect(signalReason).toEqual('My reason');
     });
+
+    it('AbortSignal.timeout(duration)', async () => {
+      const { server, baseUrl } = createFetchTargetServer();
+      await browser.url(TESTPAGE_URL);
+      const err = await browser.executeAsync(async (baseUrl, done) => {
+        setTimeout(() => {
+          done({ name: 'fail' });
+        }, 2000);
+        const signal = AbortSignal.timeout(500);
+        try {
+          let request = new Request(`${baseUrl}?sleepMillis=1000`, { signal });
+          await fetch(request);
+        } catch (err) {
+          done(err);
+        }
+      }, baseUrl);
+      expect(err.name).toBe('AbortError');
+      server.close();
+    });
   });
 };
 


### PR DESCRIPTION
Reference - https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static

`AbortSignal.timeout` is not implemented in all builds of Safari and other outdated browsers.